### PR TITLE
Feat/adc-interface

### DIFF
--- a/include/VCR_Constants.h
+++ b/include/VCR_Constants.h
@@ -15,6 +15,7 @@ constexpr int BRAKELIGHT_CONTROL_PIN = 32;
 /* -------------------------------------------------- */
 
 constexpr int ANALOG_RESOLUTION = 12;
+constexpr unsigned int CHANNELS_WITHIN_MCP_ADC = 8;
 
 /* Channels on adc_0 */
 constexpr int GLV_SENSE_CHANNEL       = 0;

--- a/include/VCR_Constants.h
+++ b/include/VCR_Constants.h
@@ -28,14 +28,14 @@ constexpr int RR_SUS_POT_CHANNEL      = 6;
 // const int UNUSED_CHANNEL       = 7;
 
 /* Channels on adc_1 */
-constexpr int THERMISTOR_0 = 0;
-constexpr int THERMISTOR_1 = 1;
-constexpr int THERMISTOR_2 = 2;
-constexpr int THERMISTOR_3 = 3;
-constexpr int THERMISTOR_4 = 4;
-constexpr int THERMISTOR_5 = 5;
-constexpr int THERMISTOR_6 = 6;
-constexpr int THERMISTOR_7 = 7;
+constexpr int THERMISTOR_0_CHANNEL = 0;
+constexpr int THERMISTOR_1_CHANNEL = 1;
+constexpr int THERMISTOR_2_CHANNEL = 2;
+constexpr int THERMISTOR_3_CHANNEL = 3;
+constexpr int THERMISTOR_4_CHANNEL = 4;
+constexpr int THERMISTOR_5_CHANNEL = 5;
+constexpr int THERMISTOR_6_CHANNEL = 6;
+constexpr int THERMISTOR_7_CHANNEL = 7;
 
 /* Scaling and offset */
 constexpr float GLV_SENSE_SCALE = (float)(24.0/((2.77149877/3.3)*4096.0)); //unsure about the multiplication by 4.0865

--- a/include/VCR_Constants.h
+++ b/include/VCR_Constants.h
@@ -24,7 +24,7 @@ constexpr int RL_SUS_POT_CHANNEL      = 5;
 constexpr int RR_SUS_POT_CHANNEL      = 6;
 // const int UNUSED_CHANNEL       = 7;
 
-/* Channels on ADC_1 */
+/* Channels on adc_1 */
 constexpr int THERMISTOR_0 = 0;
 constexpr int THERMISTOR_1 = 1;
 constexpr int THERMISTOR_2 = 2;

--- a/include/VCR_Globals.h
+++ b/include/VCR_Globals.h
@@ -4,40 +4,16 @@
 /* C++ library includes */
 #include <array> 
 
-
-#include "etl/singleton.h"
-
-/* From shared-firmware-interfaces */
-#include "MCP_ADC.h"
-
 /* From shared-firmware-types */
 #include "SharedFirmwareTypes.h"
-#include "etl/singleton.h"
 /* Local includes */
-#include "VCR_Constants.h"
 
 /* Interface and system data structs */
 extern VCRData_s vcr_data; // NOLINT
 
 /* ADC setup */
 constexpr unsigned int channels_within_mcp_adc = 8;
-struct ADCBundle_s
-{
-    
-    ADCBundle_s(const float (&adc_0_scales)[channels_within_mcp_adc],
-                const float (&adc_0_offsets)[channels_within_mcp_adc],
-                const float (&adc_1_scales)[channels_within_mcp_adc],
-                const float (&adc_1_offsets)[channels_within_mcp_adc]) :
-        adc0(ADC0_CS, MCP_ADC_DEFAULT_SPI_SDI, MCP_ADC_DEFAULT_SPI_SDO, MCP_ADC_DEFAULT_SPI_CLK, MCP_ADC_DEFAULT_SPI_SPEED, adc_0_scales, adc_0_offsets),
-        adc1(ADC1_CS, MCP_ADC_DEFAULT_SPI_SDI, MCP_ADC_DEFAULT_SPI_SDO, MCP_ADC_DEFAULT_SPI_CLK, MCP_ADC_DEFAULT_SPI_SPEED, adc_1_scales, adc_1_offsets)
-    {}
-
-    MCP_ADC <channels_within_mcp_adc> adc0;
-    MCP_ADC <channels_within_mcp_adc> adc1;
-};
 
 extern unsigned long pulseCount; // NOLINT
-
-using ADCSingletonInstance = etl::singleton<ADCBundle_s>; // Singleton for ADCs. Used to pass ADCs to other systems that need them, such as the TelemetrySystem.
 
 #endif /* VCR_GLOBALS */

--- a/include/VCR_InterfaceTasks.h
+++ b/include/VCR_InterfaceTasks.h
@@ -18,9 +18,7 @@
  * store them in structs defined in shared_firmware_types. This function relies on adc_0 being
  * defined in VCRGlobals.h.
  */
-HT_TASK::TaskResponse init_read_adc0_task(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo);
 HT_TASK::TaskResponse run_read_adc0_task(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo);
-HT_TASK::TaskResponse init_adc_bundle();
 
 /**
  * NOTE: These channels are UNUSED BY DEFAULT and exist ONLY FOR TESTING. You may edit this
@@ -30,7 +28,6 @@ HT_TASK::TaskResponse init_adc_bundle();
  * store them in a struct defined in shared_firmware_types. This function relies on adc_1 being
  * defined in VCRGlobals.h.
  */
-HT_TASK::TaskResponse init_read_adc1_task(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo);
 HT_TASK::TaskResponse run_read_adc1_task(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo);
 
 HT_TASK::TaskResponse run_sample_flowmeter(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo);

--- a/lib/interfaces/include/ADCInterface.h
+++ b/lib/interfaces/include/ADCInterface.h
@@ -1,0 +1,94 @@
+#ifndef ADCINTERFACE_H
+#define ADCINTERFACE_H
+
+#include "VCR_Globals.h"
+
+#include "MCP_ADC.h"
+#include "SharedFirmwareTypes.h"
+
+#include "etl/singleton.h"
+
+class ADCInterface
+{
+public:
+  
+
+  ADCInterface(const float (&adc_0_scales)[channels_within_mcp_adc],
+               const float (&adc_0_offsets)[channels_within_mcp_adc],
+               const float (&adc_1_scales)[channels_within_mcp_adc],
+               const float (&adc_1_offsets)[channels_within_mcp_adc]) :
+        _adc0(ADC0_CS, MCP_ADC_DEFAULT_SPI_SDI, MCP_ADC_DEFAULT_SPI_SDO, MCP_ADC_DEFAULT_SPI_CLK, MCP_ADC_DEFAULT_SPI_SPEED, adc_0_scales, adc_0_offsets),
+        _adc1(ADC1_CS, MCP_ADC_DEFAULT_SPI_SDI, MCP_ADC_DEFAULT_SPI_SDO, MCP_ADC_DEFAULT_SPI_CLK, MCP_ADC_DEFAULT_SPI_SPEED, adc_1_scales, adc_1_offsets) {}
+
+  /**
+  * Samples from ADC0
+  */
+  void tick_adc0();
+  
+  /**
+  * Samples from ADC1
+  */
+  void tick_adc1();
+
+  /* -------------------- ADC0 -------------------- */
+
+  /**
+   * @return The reading of the 24V sensor analog channel
+  */
+  AnalogConversion_s read_twentyfour_volt_sensor();
+
+  AnalogConversion_s read_current_sensor();
+
+  AnalogConversion_s read_current_reference();
+
+  AnalogConversion_s read_rl_loadcell();
+
+  AnalogConversion_s read_rr_loadcell();
+
+  AnalogConversion_s read_rl_sus_pot();
+
+  AnalogConversion_s read_rr_sus_pot();
+
+  /* -------------------- ADC1 -------------------- */
+  
+  AnalogConversion_s read_thermistor_0();
+
+  AnalogConversion_s read_thermistor_1();
+  
+  AnalogConversion_s read_thermistor_2(); 
+
+  AnalogConversion_s read_thermistor_3();
+
+  AnalogConversion_s read_thermistor_4();
+  
+  AnalogConversion_s read_thermistor_5();
+
+  AnalogConversion_s read_thermistor_6();
+
+  AnalogConversion_s read_thermistor_7();
+
+private:
+  MCP_ADC<channels_within_mcp_adc> _adc0;
+  MCP_ADC<channels_within_mcp_adc> _adc1;
+
+  /**
+  * @pre ADC interface is constructed and initialized
+  * @post 
+  * @param channel The ADC0 channel to read from 
+  * @return The ADC channel's output packet
+  */
+  AnalogConversionPacket_s<channels_within_mcp_adc> _read_adc0_channel(int channel);
+
+  /**
+  * @pre ADC interface is constructed and initialized
+  * @post 
+  * @param channel The ADC1 channel to read from 
+  * @return The ADC channel's output packet
+  */
+  AnalogConversionPacket_s<channels_within_mcp_adc> _read_adc1_channel(int channel);
+
+};
+
+using ADCInterfaceInstance = etl::singleton<ADCInterface>;
+
+#endif

--- a/lib/interfaces/include/ADCInterface.h
+++ b/lib/interfaces/include/ADCInterface.h
@@ -11,15 +11,67 @@
 class ADCInterface
 {
 public:
-  
-
-  ADCInterface(const float (&adc_0_scales)[channels_within_mcp_adc],
-               const float (&adc_0_offsets)[channels_within_mcp_adc],
-               const float (&adc_1_scales)[channels_within_mcp_adc],
-               const float (&adc_1_offsets)[channels_within_mcp_adc]) :
-        _adc0(ADC0_CS, MCP_ADC_DEFAULT_SPI_SDI, MCP_ADC_DEFAULT_SPI_SDO, MCP_ADC_DEFAULT_SPI_CLK, MCP_ADC_DEFAULT_SPI_SPEED, adc_0_scales, adc_0_offsets),
-        _adc1(ADC1_CS, MCP_ADC_DEFAULT_SPI_SDI, MCP_ADC_DEFAULT_SPI_SDO, MCP_ADC_DEFAULT_SPI_CLK, MCP_ADC_DEFAULT_SPI_SPEED, adc_1_scales, adc_1_offsets) {}
-
+  ADCInterface() : _adc0(
+      ADC0_CS,
+      MCP_ADC_DEFAULT_SPI_SDI,
+      MCP_ADC_DEFAULT_SPI_SDO,
+      MCP_ADC_DEFAULT_SPI_CLK,
+      MCP_ADC_DEFAULT_SPI_SPEED,
+      ([] {
+        static float arr[channels_within_mcp_adc] = {}; 
+        arr[GLV_SENSE_CHANNEL]        = GLV_SENSE_SCALE;
+        arr[CURRENT_SENSE_CHANNEL]    = CURRENT_SENSE_SCALE;
+        arr[REFERENCE_SENSE_CHANNEL]  = REFERENCE_SENSE_SCALE;
+        arr[RL_LOADCELL_CHANNEL]      = RL_LOADCELL_SCALE;
+        arr[RR_LOADCELL_CHANNEL]      = RR_LOADCELL_SCALE;
+        arr[RL_SUS_POT_CHANNEL]       = RL_SUS_POT_SCALE;
+        arr[RR_SUS_POT_CHANNEL]       = RR_SUS_POT_SCALE;
+        return arr;
+      }()),
+      ([] {
+        static float arr[channels_within_mcp_adc] = {};
+        arr[GLV_SENSE_CHANNEL]        = GLV_SENSE_OFFSET;
+        arr[CURRENT_SENSE_CHANNEL]    = CURRENT_SENSE_OFFSET;
+        arr[REFERENCE_SENSE_CHANNEL]  = REFERENCE_SENSE_OFFSET;
+        arr[RL_LOADCELL_CHANNEL]      = RL_LOADCELL_OFFSET;
+        arr[RR_LOADCELL_CHANNEL]      = RR_LOADCELL_OFFSET;
+        arr[RL_SUS_POT_CHANNEL]       = RL_SUS_POT_OFFSET;
+        arr[RR_SUS_POT_CHANNEL]       = RR_SUS_POT_OFFSET;
+        return arr;
+      }())
+    ),
+    _adc1(
+      ADC1_CS,
+      MCP_ADC_DEFAULT_SPI_SDI,
+      MCP_ADC_DEFAULT_SPI_SDO,
+      MCP_ADC_DEFAULT_SPI_CLK,
+      MCP_ADC_DEFAULT_SPI_SPEED,
+      ([] {
+          static float arr[channels_within_mcp_adc] = {};
+          arr[THERMISTOR_0] = THERMISTOR_0_SCALE;
+          arr[THERMISTOR_1] = THERMISTOR_1_SCALE;
+          arr[THERMISTOR_2] = THERMISTOR_2_SCALE;
+          arr[THERMISTOR_3] = THERMISTOR_3_SCALE;
+          arr[THERMISTOR_4] = THERMISTOR_4_SCALE;
+          arr[THERMISTOR_5] = THERMISTOR_5_SCALE;
+          arr[THERMISTOR_6] = THERMISTOR_6_SCALE;
+          arr[THERMISTOR_7] = THERMISTOR_7_SCALE;
+          return arr;
+      }()),
+      ([] {
+          static float arr[channels_within_mcp_adc] = {};
+          arr[THERMISTOR_0] = THERMISTOR_0_OFFSET;
+          arr[THERMISTOR_1] = THERMISTOR_1_OFFSET;
+          arr[THERMISTOR_2] = THERMISTOR_2_OFFSET;
+          arr[THERMISTOR_3] = THERMISTOR_3_OFFSET;
+          arr[THERMISTOR_4] = THERMISTOR_4_OFFSET;
+          arr[THERMISTOR_5] = THERMISTOR_5_OFFSET;
+          arr[THERMISTOR_6] = THERMISTOR_6_OFFSET;
+          arr[THERMISTOR_7] = THERMISTOR_7_OFFSET;
+          return arr;
+      }())
+    ) {} 
+        
   /**
   * Samples from ADC0
   */
@@ -35,11 +87,11 @@ public:
   /**
    * @return The reading of the 24V sensor analog channel
   */
-  AnalogConversion_s read_twentyfour_volt_sensor();
+  AnalogConversion_s read_glv();
 
-  AnalogConversion_s read_current_sensor();
+  AnalogConversion_s read_current();
 
-  AnalogConversion_s read_current_reference();
+  AnalogConversion_s read_reference();
 
   AnalogConversion_s read_rl_loadcell();
 
@@ -70,22 +122,6 @@ public:
 private:
   MCP_ADC<channels_within_mcp_adc> _adc0;
   MCP_ADC<channels_within_mcp_adc> _adc1;
-
-  /**
-  * @pre ADC interface is constructed and initialized
-  * @post 
-  * @param channel The ADC0 channel to read from 
-  * @return The ADC channel's output packet
-  */
-  AnalogConversionPacket_s<channels_within_mcp_adc> _read_adc0_channel(int channel);
-
-  /**
-  * @pre ADC interface is constructed and initialized
-  * @post 
-  * @param channel The ADC1 channel to read from 
-  * @return The ADC channel's output packet
-  */
-  AnalogConversionPacket_s<channels_within_mcp_adc> _read_adc1_channel(int channel);
 
 };
 

--- a/lib/interfaces/include/ADCInterface.h
+++ b/lib/interfaces/include/ADCInterface.h
@@ -2,6 +2,7 @@
 #define ADCINTERFACE_H
 
 #include "VCR_Globals.h"
+#include "VCR_Constants.h"
 
 #include "MCP_ADC.h"
 #include "SharedFirmwareTypes.h"
@@ -125,6 +126,8 @@ private:
 
 };
 
-using ADCInterfaceInstance = etl::singleton<ADCInterface>;
+using ADCInterfaceInstance = etl::singleton<ADCInterface>; // Singleton for ADCs. Used to pass ADCs to other systems that need them, such as the TelemetrySystem.
+
+
 
 #endif

--- a/lib/interfaces/include/ADCInterface.h
+++ b/lib/interfaces/include/ADCInterface.h
@@ -1,77 +1,101 @@
 #ifndef ADCINTERFACE_H
 #define ADCINTERFACE_H
 
-#include "VCR_Globals.h"
-#include "VCR_Constants.h"
-
 #include "MCP_ADC.h"
-#include "SharedFirmwareTypes.h"
-
 #include "etl/singleton.h"
+
+#include <array>
+#include <optional>
+
+namespace adc_default_parameters {
+  constexpr const unsigned int channels_within_mcp_adc = 8;
+}
+
+struct ADCPinout_s {
+  int adc0_spi_cs_pin;
+  int adc1_spi_cs_pin;
+};
+
+struct ADCChannels_s {
+  /* ADC 0 */
+  int glv_sense_channel;
+  int current_sense_channel;
+  int reference_sense_channel;
+  int rl_loadcell_channel;
+  int rr_loadcell_channel;
+  int rl_suspot_channel;
+  int rr_suspot_channel;
+
+  /* ADC 1 */
+  int thermistor0_channel;
+  int thermistor1_channel;
+  int thermistor2_channel;
+  int thermistor3_channel;
+  int thermistor4_channel;
+  int thermistor5_channel;
+  int thermistor6_channel;
+  int thermistor7_channel;
+};
+
+struct ADCScales_s {
+  float glv_sense_scale;
+  float current_sense_scale;
+  float reference_sense_scale;
+  float rl_loadcell_scale;
+  float rr_loadcell_scale;
+  float rl_suspot_scale;
+  float rr_suspot_scale;
+
+  float thermistor0_scale;
+  float thermistor1_scale;
+  float thermistor2_scale;
+  float thermistor3_scale;
+  float thermistor4_scale;
+  float thermistor5_scale;
+  float thermistor6_scale;
+  float thermistor7_scale;
+};
+
+struct ADCOffsets_s {
+  float glv_sense_offset;
+  float current_sense_offset;
+  float reference_sense_offset;
+  float rl_loadcell_offset;
+  float rr_loadcell_offset;
+  float rl_suspot_offset;
+  float rr_suspot_offset;
+
+  float thermistor0_offset;
+  float thermistor1_offset;
+  float thermistor2_offset;
+  float thermistor3_offset;
+  float thermistor4_offset;
+  float thermistor5_offset;
+  float thermistor6_offset;
+  float thermistor7_offset;
+};
+
+struct ADCInterfaceParams_s {
+  ADCPinout_s pinouts;
+  ADCChannels_s channels;
+  ADCScales_s scales;
+  ADCOffsets_s offsets;
+};
 
 class ADCInterface
 {
 public:
-  ADCInterface() : _adc0(
-      ADC0_CS,
-      MCP_ADC_DEFAULT_SPI_SDI,
-      MCP_ADC_DEFAULT_SPI_SDO,
-      MCP_ADC_DEFAULT_SPI_CLK,
-      MCP_ADC_DEFAULT_SPI_SPEED,
-      ([] {
-        static float arr[channels_within_mcp_adc] = {}; 
-        arr[GLV_SENSE_CHANNEL]        = GLV_SENSE_SCALE;
-        arr[CURRENT_SENSE_CHANNEL]    = CURRENT_SENSE_SCALE;
-        arr[REFERENCE_SENSE_CHANNEL]  = REFERENCE_SENSE_SCALE;
-        arr[RL_LOADCELL_CHANNEL]      = RL_LOADCELL_SCALE;
-        arr[RR_LOADCELL_CHANNEL]      = RR_LOADCELL_SCALE;
-        arr[RL_SUS_POT_CHANNEL]       = RL_SUS_POT_SCALE;
-        arr[RR_SUS_POT_CHANNEL]       = RR_SUS_POT_SCALE;
-        return arr;
-      }()),
-      ([] {
-        static float arr[channels_within_mcp_adc] = {};
-        arr[GLV_SENSE_CHANNEL]        = GLV_SENSE_OFFSET;
-        arr[CURRENT_SENSE_CHANNEL]    = CURRENT_SENSE_OFFSET;
-        arr[REFERENCE_SENSE_CHANNEL]  = REFERENCE_SENSE_OFFSET;
-        arr[RL_LOADCELL_CHANNEL]      = RL_LOADCELL_OFFSET;
-        arr[RR_LOADCELL_CHANNEL]      = RR_LOADCELL_OFFSET;
-        arr[RL_SUS_POT_CHANNEL]       = RL_SUS_POT_OFFSET;
-        arr[RR_SUS_POT_CHANNEL]       = RR_SUS_POT_OFFSET;
-        return arr;
-      }())
-    ),
-    _adc1(
-      ADC1_CS,
-      MCP_ADC_DEFAULT_SPI_SDI,
-      MCP_ADC_DEFAULT_SPI_SDO,
-      MCP_ADC_DEFAULT_SPI_CLK,
-      MCP_ADC_DEFAULT_SPI_SPEED,
-      ([] {
-          static float arr[channels_within_mcp_adc] = {};
-          arr[THERMISTOR_0] = THERMISTOR_0_SCALE;
-          arr[THERMISTOR_1] = THERMISTOR_1_SCALE;
-          arr[THERMISTOR_2] = THERMISTOR_2_SCALE;
-          arr[THERMISTOR_3] = THERMISTOR_3_SCALE;
-          arr[THERMISTOR_4] = THERMISTOR_4_SCALE;
-          arr[THERMISTOR_5] = THERMISTOR_5_SCALE;
-          arr[THERMISTOR_6] = THERMISTOR_6_SCALE;
-          arr[THERMISTOR_7] = THERMISTOR_7_SCALE;
-          return arr;
-      }()),
-      ([] {
-          static float arr[channels_within_mcp_adc] = {};
-          arr[THERMISTOR_0] = THERMISTOR_0_OFFSET;
-          arr[THERMISTOR_1] = THERMISTOR_1_OFFSET;
-          arr[THERMISTOR_2] = THERMISTOR_2_OFFSET;
-          arr[THERMISTOR_3] = THERMISTOR_3_OFFSET;
-          arr[THERMISTOR_4] = THERMISTOR_4_OFFSET;
-          arr[THERMISTOR_5] = THERMISTOR_5_OFFSET;
-          arr[THERMISTOR_6] = THERMISTOR_6_OFFSET;
-          arr[THERMISTOR_7] = THERMISTOR_7_OFFSET;
-          return arr;
-      }())
-    ) {} 
+  ADCInterface(ADCPinout_s pinouts, ADCChannels_s channels, ADCScales_s scales, ADCOffsets_s offsets) : _adc_parameters { 
+    pinouts,
+    channels,
+    scales,
+    offsets } {};
+
+  /**
+   * @pre constructor called and ADC parameters created
+   * @post _adc0 and _adc1 initialized with correct scales and offsets
+  */
+  void init();
         
   /**
   * Samples from ADC0
@@ -83,23 +107,43 @@ public:
   */
   void tick_adc1();
 
+  const ADCInterfaceParams_s& get_adc_params() const;
+
   /* -------------------- ADC0 -------------------- */
 
   /**
    * @return The reading of the 24V sensor analog channel
   */
   AnalogConversion_s read_glv();
-
+  
+  /**
+   * @return The reading of the BSPD current analog channel
+  */
   AnalogConversion_s read_bspd_current();
 
+  /**
+   * @return The reading of the BSPD reference current analog channel
+  */
   AnalogConversion_s read_bspd_reference_current();
-
+  
+  /**
+   * @return The reading of the rear left load cell analog channel
+  */
   AnalogConversion_s read_rl_loadcell();
-
+  
+  /**
+   * @return The reading of the rear right load cell analog channel
+  */
   AnalogConversion_s read_rr_loadcell();
-
+  
+  /**
+   * @return The reading of the rear left suspension potentiometer analog channel
+  */
   AnalogConversion_s read_rl_sus_pot();
-
+  
+  /**
+   * @return The reading of the rear right suspension potentiometer analog channel
+  */ 
   AnalogConversion_s read_rr_sus_pot();
 
   /* -------------------- ADC1 -------------------- */
@@ -119,15 +163,16 @@ public:
   AnalogConversion_s read_thermistor_6();
 
   AnalogConversion_s read_thermistor_7();
+  
 
 private:
-  MCP_ADC<channels_within_mcp_adc> _adc0;
-  MCP_ADC<channels_within_mcp_adc> _adc1;
+  ADCInterfaceParams_s _adc_parameters = {};
+
+  std::optional<MCP_ADC<adc_default_parameters::channels_within_mcp_adc>> _adc0;
+  std::optional<MCP_ADC<adc_default_parameters::channels_within_mcp_adc>> _adc1;
 
 };
 
 using ADCInterfaceInstance = etl::singleton<ADCInterface>; // Singleton for ADCs. Used to pass ADCs to other systems that need them, such as the TelemetrySystem.
-
-
 
 #endif

--- a/lib/interfaces/include/ADCInterface.h
+++ b/lib/interfaces/include/ADCInterface.h
@@ -89,14 +89,26 @@ public:
     pinouts,
     channels,
     scales,
-    offsets } {};
+    offsets },
+    _adc0(
+      _adc_parameters.pinouts.adc0_spi_cs_pin,
+      MCP_ADC_DEFAULT_SPI_SDI,
+      MCP_ADC_DEFAULT_SPI_SDO,
+      MCP_ADC_DEFAULT_SPI_CLK,
+      MCP_ADC_DEFAULT_SPI_SPEED,
+      adc0_scales().data(),
+      adc0_offsets().data()
+    ),
+    _adc1(
+      _adc_parameters.pinouts.adc1_spi_cs_pin,
+      MCP_ADC_DEFAULT_SPI_SDI,
+      MCP_ADC_DEFAULT_SPI_SDO,
+      MCP_ADC_DEFAULT_SPI_CLK,
+      MCP_ADC_DEFAULT_SPI_SPEED,
+      adc1_scales().data(),
+      adc1_offsets().data()
+    ) {};
 
-  /**
-   * @pre constructor called and ADC parameters created
-   * @post _adc0 and _adc1 initialized with correct scales and offsets
-  */
-  void init();
-        
   /**
   * Samples from ADC0
   */
@@ -168,8 +180,14 @@ public:
 private:
   ADCInterfaceParams_s _adc_parameters = {};
 
-  std::optional<MCP_ADC<adc_default_parameters::channels_within_mcp_adc>> _adc0;
-  std::optional<MCP_ADC<adc_default_parameters::channels_within_mcp_adc>> _adc1;
+  MCP_ADC<adc_default_parameters::channels_within_mcp_adc> _adc0;
+  MCP_ADC<adc_default_parameters::channels_within_mcp_adc> _adc1;
+
+
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc0_scales();
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc0_offsets();
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc1_scales();
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc1_offsets();
 
 };
 

--- a/lib/interfaces/include/ADCInterface.h
+++ b/lib/interfaces/include/ADCInterface.h
@@ -90,9 +90,9 @@ public:
   */
   AnalogConversion_s read_glv();
 
-  AnalogConversion_s read_current();
+  AnalogConversion_s read_bspd_current();
 
-  AnalogConversion_s read_reference();
+  AnalogConversion_s read_bspd_reference_current();
 
   AnalogConversion_s read_rl_loadcell();
 

--- a/lib/interfaces/src/ADCInterface.cpp
+++ b/lib/interfaces/src/ADCInterface.cpp
@@ -1,64 +1,130 @@
 #include "ADCInterface.h"
 
-void ADCInterface::tick_adc0() { _adc0.tick(); }
-void ADCInterface::tick_adc1() { _adc1.tick(); }
+void ADCInterface::init() {
+
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc0_scales = {};
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc0_offsets = {};
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc1_scales = {};
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc1_offsets = {};
+
+  adc0_scales.at(_adc_parameters.channels.glv_sense_channel)          = _adc_parameters.scales.glv_sense_scale; 
+  adc0_scales.at(_adc_parameters.channels.current_sense_channel)      = _adc_parameters.scales.current_sense_scale;
+  adc0_scales.at(_adc_parameters.channels.reference_sense_channel)    = _adc_parameters.scales.reference_sense_scale;
+  adc0_scales.at(_adc_parameters.channels.rl_loadcell_channel)        = _adc_parameters.scales.rl_loadcell_scale;
+  adc0_scales.at(_adc_parameters.channels.rr_loadcell_channel)        = _adc_parameters.scales.rr_loadcell_scale;
+  adc0_scales.at(_adc_parameters.channels.rl_suspot_channel)          = _adc_parameters.scales.rl_suspot_scale;
+  adc0_scales.at(_adc_parameters.channels.rr_suspot_channel)          = _adc_parameters.scales.rr_suspot_scale;
+
+  adc0_offsets.at(_adc_parameters.channels.glv_sense_channel)         = _adc_parameters.offsets.glv_sense_offset; 
+  adc0_offsets.at(_adc_parameters.channels.current_sense_channel)     = _adc_parameters.offsets.current_sense_offset;
+  adc0_offsets.at(_adc_parameters.channels.reference_sense_channel)   = _adc_parameters.offsets.reference_sense_offset;
+  adc0_offsets.at(_adc_parameters.channels.rl_loadcell_channel)       = _adc_parameters.offsets.rl_loadcell_offset;
+  adc0_offsets.at(_adc_parameters.channels.rr_loadcell_channel)       = _adc_parameters.offsets.rr_loadcell_offset;
+  adc0_offsets.at(_adc_parameters.channels.rl_suspot_channel)         = _adc_parameters.offsets.rl_suspot_offset;
+  adc0_offsets.at(_adc_parameters.channels.rr_suspot_channel)         = _adc_parameters.offsets.rr_suspot_offset;
+
+  adc1_scales.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.scales.thermistor0_scale;
+  adc1_scales.at(_adc_parameters.channels.thermistor1_channel)        = _adc_parameters.scales.thermistor1_scale;
+  adc1_scales.at(_adc_parameters.channels.thermistor2_channel)        = _adc_parameters.scales.thermistor2_scale;
+  adc1_scales.at(_adc_parameters.channels.thermistor3_channel)        = _adc_parameters.scales.thermistor3_scale;
+  adc1_scales.at(_adc_parameters.channels.thermistor4_channel)        = _adc_parameters.scales.thermistor4_scale;
+  adc1_scales.at(_adc_parameters.channels.thermistor5_channel)        = _adc_parameters.scales.thermistor5_scale;
+  adc1_scales.at(_adc_parameters.channels.thermistor6_channel)        = _adc_parameters.scales.thermistor6_scale;
+  adc1_scales.at(_adc_parameters.channels.thermistor7_channel)        = _adc_parameters.scales.thermistor7_scale;
+
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor0_offset;
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor1_offset;
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor2_offset;
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor3_offset;
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor4_offset;
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor5_offset;
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor6_offset;
+  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor7_offset;
+
+  _adc0.emplace(
+    _adc_parameters.pinouts.adc0_spi_cs_pin, 
+    MCP_ADC_DEFAULT_SPI_SDI, 
+    MCP_ADC_DEFAULT_SPI_SDO, 
+    MCP_ADC_DEFAULT_SPI_CLK,
+    MCP_ADC_DEFAULT_SPI_SPEED,
+    adc0_scales.data(),
+    adc0_offsets.data()
+  );
+
+  _adc1.emplace(
+    _adc_parameters.pinouts.adc1_spi_cs_pin, 
+    MCP_ADC_DEFAULT_SPI_SDI, 
+    MCP_ADC_DEFAULT_SPI_SDO, 
+    MCP_ADC_DEFAULT_SPI_CLK,
+    MCP_ADC_DEFAULT_SPI_SPEED,
+    adc1_scales.data(),
+    adc1_offsets.data()
+  );
+}
+
+void ADCInterface::tick_adc0() { _adc0->tick(); }
+void ADCInterface::tick_adc1() { _adc1->tick(); }
+
+const ADCInterfaceParams_s& ADCInterface::get_adc_params() const {
+    return _adc_parameters;
+}
 
 AnalogConversion_s ADCInterface::read_glv() {
-  return _adc0.data.conversions[GLV_SENSE_CHANNEL];
+  return _adc0->data.conversions.at(_adc_parameters.channels.glv_sense_channel);
 }
 
 AnalogConversion_s ADCInterface::read_bspd_current() {
-  return _adc0.data.conversions[CURRENT_SENSE_CHANNEL];
+  return _adc0->data.conversions.at(_adc_parameters.channels.current_sense_channel);
 }
 
 AnalogConversion_s ADCInterface::read_bspd_reference_current() {
-  return _adc0.data.conversions[REFERENCE_SENSE_CHANNEL];
+  return _adc0->data.conversions.at(_adc_parameters.channels.reference_sense_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rl_loadcell() {
-  return _adc0.data.conversions[RL_LOADCELL_CHANNEL];
+  return _adc0->data.conversions.at(_adc_parameters.channels.rl_loadcell_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rr_loadcell() {
-  return _adc0.data.conversions[RR_LOADCELL_CHANNEL];
+  return _adc0->data.conversions.at(_adc_parameters.channels.rr_loadcell_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rl_sus_pot() {
-  return _adc0.data.conversions[RL_SUS_POT_CHANNEL];
+  return _adc0->data.conversions.at(_adc_parameters.channels.rl_suspot_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rr_sus_pot() {
-  return _adc0.data.conversions[RR_SUS_POT_CHANNEL];
+  return _adc0->data.conversions.at(_adc_parameters.channels.rr_suspot_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_0() {
-  return _adc1.data.conversions[THERMISTOR_0];
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor0_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_1() {
-  return _adc1.data.conversions[THERMISTOR_1];
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor1_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_2() {
-  return _adc1.data.conversions[THERMISTOR_2];
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor2_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_3() {
-  return _adc1.data.conversions[THERMISTOR_3];
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor3_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_4() {
-  return _adc1.data.conversions[THERMISTOR_4];
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor4_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_5() {
-  return _adc1.data.conversions[THERMISTOR_5];  
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor5_channel);  
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_6() {
-  return _adc1.data.conversions[THERMISTOR_6];
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor6_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_7() {
-  return _adc1.data.conversions[THERMISTOR_7];
+  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor7_channel);
 }

--- a/lib/interfaces/src/ADCInterface.cpp
+++ b/lib/interfaces/src/ADCInterface.cpp
@@ -1,0 +1,1 @@
+#include "ACUInterface.h"

--- a/lib/interfaces/src/ADCInterface.cpp
+++ b/lib/interfaces/src/ADCInterface.cpp
@@ -1,130 +1,126 @@
 #include "ADCInterface.h"
 
-void ADCInterface::init() {
-
-  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc0_scales = {};
-  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc0_offsets = {};
-  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc1_scales = {};
-  std::array<float, adc_default_parameters::channels_within_mcp_adc> adc1_offsets = {};
-
-  adc0_scales.at(_adc_parameters.channels.glv_sense_channel)          = _adc_parameters.scales.glv_sense_scale; 
-  adc0_scales.at(_adc_parameters.channels.current_sense_channel)      = _adc_parameters.scales.current_sense_scale;
-  adc0_scales.at(_adc_parameters.channels.reference_sense_channel)    = _adc_parameters.scales.reference_sense_scale;
-  adc0_scales.at(_adc_parameters.channels.rl_loadcell_channel)        = _adc_parameters.scales.rl_loadcell_scale;
-  adc0_scales.at(_adc_parameters.channels.rr_loadcell_channel)        = _adc_parameters.scales.rr_loadcell_scale;
-  adc0_scales.at(_adc_parameters.channels.rl_suspot_channel)          = _adc_parameters.scales.rl_suspot_scale;
-  adc0_scales.at(_adc_parameters.channels.rr_suspot_channel)          = _adc_parameters.scales.rr_suspot_scale;
-
-  adc0_offsets.at(_adc_parameters.channels.glv_sense_channel)         = _adc_parameters.offsets.glv_sense_offset; 
-  adc0_offsets.at(_adc_parameters.channels.current_sense_channel)     = _adc_parameters.offsets.current_sense_offset;
-  adc0_offsets.at(_adc_parameters.channels.reference_sense_channel)   = _adc_parameters.offsets.reference_sense_offset;
-  adc0_offsets.at(_adc_parameters.channels.rl_loadcell_channel)       = _adc_parameters.offsets.rl_loadcell_offset;
-  adc0_offsets.at(_adc_parameters.channels.rr_loadcell_channel)       = _adc_parameters.offsets.rr_loadcell_offset;
-  adc0_offsets.at(_adc_parameters.channels.rl_suspot_channel)         = _adc_parameters.offsets.rl_suspot_offset;
-  adc0_offsets.at(_adc_parameters.channels.rr_suspot_channel)         = _adc_parameters.offsets.rr_suspot_offset;
-
-  adc1_scales.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.scales.thermistor0_scale;
-  adc1_scales.at(_adc_parameters.channels.thermistor1_channel)        = _adc_parameters.scales.thermistor1_scale;
-  adc1_scales.at(_adc_parameters.channels.thermistor2_channel)        = _adc_parameters.scales.thermistor2_scale;
-  adc1_scales.at(_adc_parameters.channels.thermistor3_channel)        = _adc_parameters.scales.thermistor3_scale;
-  adc1_scales.at(_adc_parameters.channels.thermistor4_channel)        = _adc_parameters.scales.thermistor4_scale;
-  adc1_scales.at(_adc_parameters.channels.thermistor5_channel)        = _adc_parameters.scales.thermistor5_scale;
-  adc1_scales.at(_adc_parameters.channels.thermistor6_channel)        = _adc_parameters.scales.thermistor6_scale;
-  adc1_scales.at(_adc_parameters.channels.thermistor7_channel)        = _adc_parameters.scales.thermistor7_scale;
-
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor0_offset;
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor1_offset;
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor2_offset;
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor3_offset;
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor4_offset;
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor5_offset;
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor6_offset;
-  adc1_offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor7_offset;
-
-  _adc0.emplace(
-    _adc_parameters.pinouts.adc0_spi_cs_pin, 
-    MCP_ADC_DEFAULT_SPI_SDI, 
-    MCP_ADC_DEFAULT_SPI_SDO, 
-    MCP_ADC_DEFAULT_SPI_CLK,
-    MCP_ADC_DEFAULT_SPI_SPEED,
-    adc0_scales.data(),
-    adc0_offsets.data()
-  );
-
-  _adc1.emplace(
-    _adc_parameters.pinouts.adc1_spi_cs_pin, 
-    MCP_ADC_DEFAULT_SPI_SDI, 
-    MCP_ADC_DEFAULT_SPI_SDO, 
-    MCP_ADC_DEFAULT_SPI_CLK,
-    MCP_ADC_DEFAULT_SPI_SPEED,
-    adc1_scales.data(),
-    adc1_offsets.data()
-  );
-}
-
-void ADCInterface::tick_adc0() { _adc0->tick(); }
-void ADCInterface::tick_adc1() { _adc1->tick(); }
+void ADCInterface::tick_adc0() { _adc0.tick(); }
+void ADCInterface::tick_adc1() { _adc1.tick(); }
 
 const ADCInterfaceParams_s& ADCInterface::get_adc_params() const {
     return _adc_parameters;
 }
 
+std::array<float, adc_default_parameters::channels_within_mcp_adc> ADCInterface::adc0_scales() {
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> scales = {};
+
+  scales.at(_adc_parameters.channels.glv_sense_channel)          = _adc_parameters.scales.glv_sense_scale; 
+  scales.at(_adc_parameters.channels.current_sense_channel)      = _adc_parameters.scales.current_sense_scale;
+  scales.at(_adc_parameters.channels.reference_sense_channel)    = _adc_parameters.scales.reference_sense_scale;
+  scales.at(_adc_parameters.channels.rl_loadcell_channel)        = _adc_parameters.scales.rl_loadcell_scale;
+  scales.at(_adc_parameters.channels.rr_loadcell_channel)        = _adc_parameters.scales.rr_loadcell_scale;
+  scales.at(_adc_parameters.channels.rl_suspot_channel)          = _adc_parameters.scales.rl_suspot_scale;
+  scales.at(_adc_parameters.channels.rr_suspot_channel)          = _adc_parameters.scales.rr_suspot_scale;
+  
+  return scales;
+}
+
+std::array<float, adc_default_parameters::channels_within_mcp_adc> ADCInterface::adc0_offsets() {
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> offsets = {};
+
+  offsets.at(_adc_parameters.channels.glv_sense_channel)          = _adc_parameters.offsets.glv_sense_offset; 
+  offsets.at(_adc_parameters.channels.current_sense_channel)      = _adc_parameters.offsets.current_sense_offset;
+  offsets.at(_adc_parameters.channels.reference_sense_channel)    = _adc_parameters.offsets.reference_sense_offset;
+  offsets.at(_adc_parameters.channels.rl_loadcell_channel)        = _adc_parameters.offsets.rl_loadcell_offset;
+  offsets.at(_adc_parameters.channels.rr_loadcell_channel)        = _adc_parameters.offsets.rr_loadcell_offset;
+  offsets.at(_adc_parameters.channels.rl_suspot_channel)          = _adc_parameters.offsets.rl_suspot_offset;
+  offsets.at(_adc_parameters.channels.rr_suspot_channel)          = _adc_parameters.offsets.rr_suspot_offset;
+  
+  return offsets;
+}
+
+std::array<float, adc_default_parameters::channels_within_mcp_adc> ADCInterface::adc1_scales() {
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> scales = {};
+  
+  scales.at(_adc_parameters.channels.thermistor0_channel)         = _adc_parameters.scales.thermistor0_scale;
+  scales.at(_adc_parameters.channels.thermistor1_channel)         = _adc_parameters.scales.thermistor1_scale;
+  scales.at(_adc_parameters.channels.thermistor2_channel)         = _adc_parameters.scales.thermistor2_scale;
+  scales.at(_adc_parameters.channels.thermistor3_channel)         = _adc_parameters.scales.thermistor3_scale;
+  scales.at(_adc_parameters.channels.thermistor4_channel)         = _adc_parameters.scales.thermistor4_scale;
+  scales.at(_adc_parameters.channels.thermistor5_channel)         = _adc_parameters.scales.thermistor5_scale;
+  scales.at(_adc_parameters.channels.thermistor6_channel)         = _adc_parameters.scales.thermistor6_scale;
+  scales.at(_adc_parameters.channels.thermistor7_channel)         = _adc_parameters.scales.thermistor7_scale;
+   
+  return scales;
+}
+
+std::array<float, adc_default_parameters::channels_within_mcp_adc> ADCInterface::adc1_offsets() {
+  std::array<float, adc_default_parameters::channels_within_mcp_adc> offsets = {};
+
+  offsets.at(_adc_parameters.channels.thermistor0_channel)        = _adc_parameters.offsets.thermistor0_offset; 
+  offsets.at(_adc_parameters.channels.thermistor1_channel)        = _adc_parameters.offsets.thermistor1_offset; 
+  offsets.at(_adc_parameters.channels.thermistor2_channel)        = _adc_parameters.offsets.thermistor2_offset; 
+  offsets.at(_adc_parameters.channels.thermistor3_channel)        = _adc_parameters.offsets.thermistor3_offset; 
+  offsets.at(_adc_parameters.channels.thermistor4_channel)        = _adc_parameters.offsets.thermistor4_offset; 
+  offsets.at(_adc_parameters.channels.thermistor5_channel)        = _adc_parameters.offsets.thermistor5_offset; 
+  offsets.at(_adc_parameters.channels.thermistor6_channel)        = _adc_parameters.offsets.thermistor6_offset; 
+  offsets.at(_adc_parameters.channels.thermistor7_channel)        = _adc_parameters.offsets.thermistor7_offset; 
+  
+  return offsets;
+}
+
 AnalogConversion_s ADCInterface::read_glv() {
-  return _adc0->data.conversions.at(_adc_parameters.channels.glv_sense_channel);
+  return _adc0.data.conversions.at(_adc_parameters.channels.glv_sense_channel);
 }
 
 AnalogConversion_s ADCInterface::read_bspd_current() {
-  return _adc0->data.conversions.at(_adc_parameters.channels.current_sense_channel);
+  return _adc0.data.conversions.at(_adc_parameters.channels.current_sense_channel);
 }
 
 AnalogConversion_s ADCInterface::read_bspd_reference_current() {
-  return _adc0->data.conversions.at(_adc_parameters.channels.reference_sense_channel);
+  return _adc0.data.conversions.at(_adc_parameters.channels.reference_sense_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rl_loadcell() {
-  return _adc0->data.conversions.at(_adc_parameters.channels.rl_loadcell_channel);
+  return _adc0.data.conversions.at(_adc_parameters.channels.rl_loadcell_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rr_loadcell() {
-  return _adc0->data.conversions.at(_adc_parameters.channels.rr_loadcell_channel);
+  return _adc0.data.conversions.at(_adc_parameters.channels.rr_loadcell_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rl_sus_pot() {
-  return _adc0->data.conversions.at(_adc_parameters.channels.rl_suspot_channel);
+  return _adc0.data.conversions.at(_adc_parameters.channels.rl_suspot_channel);
 }
 
 AnalogConversion_s ADCInterface::read_rr_sus_pot() {
-  return _adc0->data.conversions.at(_adc_parameters.channels.rr_suspot_channel);
+  return _adc0.data.conversions.at(_adc_parameters.channels.rr_suspot_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_0() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor0_channel);
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor0_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_1() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor1_channel);
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor1_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_2() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor2_channel);
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor2_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_3() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor3_channel);
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor3_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_4() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor4_channel);
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor4_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_5() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor5_channel);  
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor5_channel);  
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_6() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor6_channel);
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor6_channel);
 }
 
 AnalogConversion_s ADCInterface::read_thermistor_7() {
-  return _adc1->data.conversions.at(_adc_parameters.channels.thermistor7_channel);
+  return _adc1.data.conversions.at(_adc_parameters.channels.thermistor7_channel);
 }

--- a/lib/interfaces/src/ADCInterface.cpp
+++ b/lib/interfaces/src/ADCInterface.cpp
@@ -1,1 +1,64 @@
-#include "ACUInterface.h"
+#include "ADCInterface.h"
+
+void ADCInterface::tick_adc0() { _adc0.tick(); }
+void ADCInterface::tick_adc1() { _adc1.tick(); }
+
+AnalogConversion_s ADCInterface::read_glv() {
+  return _adc0.data.conversions[GLV_SENSE_CHANNEL];
+}
+
+AnalogConversion_s ADCInterface::read_current() {
+  return _adc0.data.conversions[CURRENT_SENSE_CHANNEL];
+}
+
+AnalogConversion_s ADCInterface::read_reference() {
+  return _adc0.data.conversions[REFERENCE_SENSE_CHANNEL];
+}
+
+AnalogConversion_s ADCInterface::read_rl_loadcell() {
+  return _adc0.data.conversions[RL_LOADCELL_CHANNEL];
+}
+
+AnalogConversion_s ADCInterface::read_rr_loadcell() {
+  return _adc0.data.conversions[RR_LOADCELL_CHANNEL];
+}
+
+AnalogConversion_s ADCInterface::read_rl_sus_pot() {
+  return _adc0.data.conversions[RL_SUS_POT_CHANNEL];
+}
+
+AnalogConversion_s ADCInterface::read_rr_sus_pot() {
+  return _adc0.data.conversions[RR_SUS_POT_CHANNEL];
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_0() {
+  return _adc1.data.conversions[THERMISTOR_0];
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_1() {
+  return _adc1.data.conversions[THERMISTOR_1];
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_2() {
+  return _adc1.data.conversions[THERMISTOR_2];
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_3() {
+  return _adc1.data.conversions[THERMISTOR_3];
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_4() {
+  return _adc1.data.conversions[THERMISTOR_4];
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_5() {
+  return _adc1.data.conversions[THERMISTOR_5];  
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_6() {
+  return _adc1.data.conversions[THERMISTOR_6];
+}
+
+AnalogConversion_s ADCInterface::read_thermistor_7() {
+  return _adc1.data.conversions[THERMISTOR_7];
+}

--- a/lib/interfaces/src/ADCInterface.cpp
+++ b/lib/interfaces/src/ADCInterface.cpp
@@ -7,11 +7,11 @@ AnalogConversion_s ADCInterface::read_glv() {
   return _adc0.data.conversions[GLV_SENSE_CHANNEL];
 }
 
-AnalogConversion_s ADCInterface::read_current() {
+AnalogConversion_s ADCInterface::read_bspd_current() {
   return _adc0.data.conversions[CURRENT_SENSE_CHANNEL];
 }
 
-AnalogConversion_s ADCInterface::read_reference() {
+AnalogConversion_s ADCInterface::read_bspd_reference_current() {
   return _adc0.data.conversions[REFERENCE_SENSE_CHANNEL];
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,7 @@
 [common]
 lib_deps_shared = 
     https://github.com/hytech-racing/shared_firmware_systems.git
-    https://github.com/hytech-racing/shared_firmware_types.git#analog-conversion-array-fix
+    https://github.com/hytech-racing/shared_firmware_types.git#mcp-adc-stdarray-fix
     Embedded Template Library@^20.39.4
     https://github.com/hytech-racing/HT_SCHED.git#c13cff762c59dd82a8c273e3e98fd1a80622656d
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,7 +6,7 @@
 [common]
 lib_deps_shared = 
     https://github.com/hytech-racing/shared_firmware_systems.git
-    https://github.com/hytech-racing/shared_firmware_types.git#903e01dac8e49ea4a1aecfe1a05d252eae2f0641
+    https://github.com/hytech-racing/shared_firmware_types.git#analog-conversion-array-fix
     Embedded Template Library@^20.39.4
     https://github.com/hytech-racing/HT_SCHED.git#c13cff762c59dd82a8c273e3e98fd1a80622656d
 

--- a/src/VCR_Globals.cpp
+++ b/src/VCR_Globals.cpp
@@ -1,8 +1,5 @@
 #include "VCR_Globals.h"
-#include "VCR_Constants.h"
 
-/* From shared-firmware-interfaces */
-#include "MCP_ADC.h"
 
 /* From shared-firmware-types */
 #include "SharedFirmwareTypes.h"

--- a/src/VCR_InterfaceTasks.cpp
+++ b/src/VCR_InterfaceTasks.cpp
@@ -30,8 +30,8 @@ HT_TASK::TaskResponse run_read_adc0_task(const unsigned long& sysMicros, const H
     ADCInterfaceInstance::instance().tick_adc0();
 
     vcr_data.interface_data.current_sensor_data.twentyfour_volt_sensor = ADCInterfaceInstance::instance().read_glv().conversion;
-    vcr_data.interface_data.current_sensor_data.current_sensor_unfiltered = ADCInterfaceInstance::instance().read_current().conversion;
-    vcr_data.interface_data.current_sensor_data.current_refererence_unfiltered = ADCInterfaceInstance::instance().read_reference().conversion;
+    vcr_data.interface_data.current_sensor_data.current_sensor_unfiltered = ADCInterfaceInstance::instance().read_bspd_current().conversion;
+    vcr_data.interface_data.current_sensor_data.current_refererence_unfiltered = ADCInterfaceInstance::instance().read_bspd_reference_current().conversion;
 
     vcr_data.interface_data.rear_loadcell_data.RL_loadcell_analog = apply_iir_filter(LOADCELL_IIR_FILTER_ALPHA,
         vcr_data.interface_data.rear_loadcell_data.RL_loadcell_analog,

--- a/src/VCR_InterfaceTasks.cpp
+++ b/src/VCR_InterfaceTasks.cpp
@@ -63,24 +63,29 @@ HT_TASK::TaskResponse run_read_adc1_task(const unsigned long& sysMicros, const H
 
     vcr_data.interface_data.thermistor_data.thermistor_0.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_0().conversion;
     vcr_data.interface_data.thermistor_data.thermistor_1.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_1().conversion;
+    /*
     vcr_data.interface_data.thermistor_data.thermistor_2.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_2().conversion;
     vcr_data.interface_data.thermistor_data.thermistor_3.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_3().conversion;
     vcr_data.interface_data.thermistor_data.thermistor_4.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_4().conversion;
     vcr_data.interface_data.thermistor_data.thermistor_5.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_5().conversion;
     vcr_data.interface_data.thermistor_data.thermistor_6.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_6().conversion;
     vcr_data.interface_data.thermistor_data.thermistor_7.thermistor_analog = ADCInterfaceInstance::instance().read_thermistor_7().conversion;
+    */
 
     // with a 8.2k resistor for R1 and the sensor as R2, the formula for actual temperature should follow 198 - 31 * ln(analog_value)
     vcr_data.interface_data.thermistor_data.thermistor_0.thermistor_degrees_C = COOLANT_TEMP_OFFSET + (COOLANT_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_0.thermistor_analog)); // log() is ln
     vcr_data.interface_data.thermistor_data.thermistor_1.thermistor_degrees_C = COOLANT_TEMP_OFFSET + (COOLANT_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_1.thermistor_analog)); // log() is ln
+    
 
-    // other thermistors computation is not as straight forward, not sure what these are
+    /*
+    other thermistors computation is not as straight forward, not sure what these are
     vcr_data.interface_data.thermistor_data.thermistor_2.thermistor_degrees_C = TEST_TEMP_OFFSET + (TEST_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_2.thermistor_analog));
     vcr_data.interface_data.thermistor_data.thermistor_3.thermistor_degrees_C = TEST_TEMP_OFFSET + (TEST_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_3.thermistor_analog));
     vcr_data.interface_data.thermistor_data.thermistor_4.thermistor_degrees_C = TEST_TEMP_OFFSET + (TEST_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_4.thermistor_analog));
     vcr_data.interface_data.thermistor_data.thermistor_5.thermistor_degrees_C = TEST_TEMP_OFFSET + (TEST_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_5.thermistor_analog));
     vcr_data.interface_data.thermistor_data.thermistor_6.thermistor_degrees_C = TEST_TEMP_OFFSET + (TEST_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_6.thermistor_analog));
     vcr_data.interface_data.thermistor_data.thermistor_7.thermistor_degrees_C = TEST_TEMP_OFFSET + (TEST_TEMP_SCALE * log(vcr_data.interface_data.thermistor_data.thermistor_7.thermistor_analog));
+    */
   
     return HT_TASK::TaskResponse::YIELD;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -376,9 +376,6 @@ void setup() {
       }
     );
   
-  // Initialize ADC scales and offsets
-  ADCInterfaceInstance::instance().init();
-    
     
     scheduler.schedule(adc_0_sample_task);
     scheduler.schedule(adc_1_sample_task);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -320,9 +320,66 @@ void setup() {
     handle_CAN_setup(VCRCANInterfaceImpl::INVERTER_CAN, inv_CAN_baudrate, &VCRCANInterfaceImpl::on_inverter_can_receive);
     handle_CAN_setup(VCRCANInterfaceImpl::TELEM_CAN, telem_CAN_baudrate, &VCRCANInterfaceImpl::on_telem_can_receive);
 
-    // Initialize ADC interface
-    ADCInterfaceInstance::create();
-
+    // Instantiate ADC interface
+    ADCInterfaceInstance::create(
+      ADCPinout_s {ADC0_CS, ADC1_CS},
+      ADCChannels_s {
+        GLV_SENSE_CHANNEL,
+        CURRENT_SENSE_CHANNEL,
+        REFERENCE_SENSE_CHANNEL,
+        RL_LOADCELL_CHANNEL,
+        RR_LOADCELL_CHANNEL,
+        RL_SUS_POT_CHANNEL,
+        RR_SUS_POT_CHANNEL,
+        THERMISTOR_0,
+        THERMISTOR_1,
+        THERMISTOR_2,
+        THERMISTOR_3,
+        THERMISTOR_4,
+        THERMISTOR_5,
+        THERMISTOR_6,
+        THERMISTOR_7
+      },
+      ADCScales_s {
+        GLV_SENSE_SCALE,
+        CURRENT_SENSE_SCALE,
+        REFERENCE_SENSE_SCALE,
+        RL_LOADCELL_SCALE,
+        RR_LOADCELL_SCALE,
+        RL_SUS_POT_SCALE,
+        RR_SUS_POT_SCALE,
+        THERMISTOR_0_SCALE,
+        THERMISTOR_1_SCALE,
+        THERMISTOR_2_SCALE,
+        THERMISTOR_3_SCALE,
+        THERMISTOR_4_SCALE,
+        THERMISTOR_5_SCALE,
+        THERMISTOR_6_SCALE,
+        THERMISTOR_7_SCALE,
+      },
+      ADCOffsets_s {
+        GLV_SENSE_OFFSET,
+        CURRENT_SENSE_OFFSET,
+        REFERENCE_SENSE_OFFSET,
+        RL_LOADCELL_OFFSET,
+        RR_LOADCELL_OFFSET,
+        RL_SUS_POT_OFFSET,
+        RR_SUS_POT_OFFSET,
+        THERMISTOR_0_OFFSET,
+        THERMISTOR_1_OFFSET,
+        THERMISTOR_2_OFFSET,
+        THERMISTOR_3_OFFSET,
+        THERMISTOR_4_OFFSET,
+        THERMISTOR_5_OFFSET,
+        THERMISTOR_6_OFFSET,
+        THERMISTOR_7_OFFSET,
+      }
+    );
+  
+  // Initialize ADC scales and offsets
+  ADCInterfaceInstance::instance().init();
+    
+    
     scheduler.schedule(adc_0_sample_task);
     scheduler.schedule(adc_1_sample_task);
     scheduler.schedule(kick_watchdog_task);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,14 +331,14 @@ void setup() {
         RR_LOADCELL_CHANNEL,
         RL_SUS_POT_CHANNEL,
         RR_SUS_POT_CHANNEL,
-        THERMISTOR_0,
-        THERMISTOR_1,
-        THERMISTOR_2,
-        THERMISTOR_3,
-        THERMISTOR_4,
-        THERMISTOR_5,
-        THERMISTOR_6,
-        THERMISTOR_7
+        THERMISTOR_0_CHANNEL,
+        THERMISTOR_1_CHANNEL,
+        THERMISTOR_2_CHANNEL,
+        THERMISTOR_3_CHANNEL,
+        THERMISTOR_4_CHANNEL,
+        THERMISTOR_5_CHANNEL,
+        THERMISTOR_6_CHANNEL,
+        THERMISTOR_7_CHANNEL
       },
       ADCScales_s {
         GLV_SENSE_SCALE,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include "VCR_Globals.h"
 #include "VCR_InterfaceTasks.h"
 #include "VCRCANInterfaceImpl.h"
+#include "ADCInterface.h"
 #include "DrivebrainInterface.h"
 #include "InverterInterface.h"
 #include "DrivetrainSystem.h"
@@ -97,6 +98,7 @@ etl::delegate<void(bool)> set_ef_pin_active = etl::delegate<void(bool)>::create(
 
 /* Scheduler setup */
 HT_SCHED::Scheduler& scheduler = HT_SCHED::Scheduler::getInstance();
+
 
 /* Task Declarations */
 HT_TASK::Task adc_0_sample_task(HT_TASK::DUMMY_FUNCTION, run_read_adc0_task, adc0_priority, adc0_sample_period_us);
@@ -318,7 +320,8 @@ void setup() {
     handle_CAN_setup(VCRCANInterfaceImpl::INVERTER_CAN, inv_CAN_baudrate, &VCRCANInterfaceImpl::on_inverter_can_receive);
     handle_CAN_setup(VCRCANInterfaceImpl::TELEM_CAN, telem_CAN_baudrate, &VCRCANInterfaceImpl::on_telem_can_receive);
 
-    init_adc_bundle();
+    // Initialize ADC interface
+    ADCInterfaceInstance::create();
 
     scheduler.schedule(adc_0_sample_task);
     scheduler.schedule(adc_1_sample_task);


### PR DESCRIPTION
replaces the current implementation of directly reading instantiated adc channels 